### PR TITLE
Change Playlist Response from href into id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /node_modules
+load_keys.sh

--- a/README.md
+++ b/README.md
@@ -2,11 +2,12 @@
 WIP: RESTful APIs for TuneUp
 
 ## Endpoints
-| Endpoint                    | Description                      | Parameters | Response |
-|-----------------------------|----------------------------------|------------|----------|
-| /v1/spotify/authorize/      | Returns Spotify bearer auth key  | N/A        |[Spotify Documentation](https://developer.spotify.com/documentation/general/guides/authorization-guide/#client-credentials-flow)|
-| /v1/spotify/get_categories/ | Returns Spotify music categories | key=oauthkey        |[Spotify Documentation](https://developer.spotify.com/documentation/web-api/reference/browse/get-list-categories/)|
-|/v1/spotify/playlist_search/| Returns Spotify playlist query of given search|key=oauthkey, q=query| See below |
+| Endpoint | Description | Parameters | Response |
+|----------|-------------|------------|----------|
+| /v1/spotify/authorize/| Returns Spotify bearer auth key  | N/A        |[Spotify Documentation](https://developer.spotify.com/documentation/general/guides/authorization-guide/#client-credentials-flow)|
+| /v1/spotify/get_categories/ | Returns Spotify music categories | key=oauthkey | [Spotify Documentation](https://developer.spotify.com/documentation/web-api/reference/browse/get-list-categories/)|
+| /v1/spotify/playlist_search/| Returns Spotify playlist query of given search|key=oauthkey, q=query| See below |
+| /v1/spotify/get_playlist/ | Returns songs and sample tracks | key=oauthkey, id=playlistid | See below |
 
 
 ## Sample Responses
@@ -22,5 +23,21 @@ WIP: RESTful APIs for TuneUp
       "image": [IMAGE URL]
     }
   ]
+}
+```
+
+### v1/spotify/get_playlist/
+```
+  {
+    "tracks": [
+        {
+            "id": [ID],
+            "name": [NAME],
+            "preview_url": [URL],
+            "image": [URL]
+        }
+    ],
+    "tracksWithPreview": 1,
+    "totalTracks": 1
 }
 ```

--- a/server/providers/spotify/authorize.js
+++ b/server/providers/spotify/authorize.js
@@ -22,7 +22,7 @@ export const authorize = (res) => {
       'grant_type': 'client_credentials'
     }
   };
-  request(options, function (error, response) { 
+  request(options, (error, response) => { 
       if (error) {
           throw new Error(error);
       }

--- a/server/providers/spotify/get_playlist.js
+++ b/server/providers/spotify/get_playlist.js
@@ -1,0 +1,48 @@
+import request from 'request';
+import { urls } from './';
+
+
+const process_tracks = body => {
+  const response = {};
+  let previewUrlCount = 0;
+  response['tracks'] = [];
+  for (const item of body['items']){
+    const track = item.track;
+    const previewUrl = track.preview_url;
+    if (previewUrl){
+      previewUrlCount++;
+    }
+    response['tracks'].push({
+      id: track.id || '',
+      name: track.name || '',
+      preview_url: previewUrl || '',
+      image: track.album.images[0].url,
+    });
+  }
+  response['tracksWithPreview'] = previewUrlCount;
+  response['totalTracks'] = response.tracks.length;
+  return response;
+};
+
+export const get_playlist = (res, key, id) => {
+  const options = {
+    'method': 'GET',
+    'url': urls.get_playlist(id),
+    'headers': {
+      'Authorization': `Bearer ${key}`
+    }
+  };
+  request(options, (error, response) => {
+    if (error) {
+      throw new Error(error);
+    }
+    const returned_tracks = JSON.parse(response.body);
+    if (response.statusCode != 200) {
+      res.status(response.statusCode).send(query_results);
+    } else {
+      res.status(response.statusCode).send(
+        process_tracks(returned_tracks)
+      );
+    }
+  });
+};

--- a/server/providers/spotify/index.js
+++ b/server/providers/spotify/index.js
@@ -3,10 +3,12 @@ import { urls } from './urls';
 import { authorize } from './authorize';
 import { get_categories } from './get_categories';
 import { playlist_search } from "./playlist_search";
+import { get_playlist } from './get_playlist';
 
 export {
     urls,
     authorize,
     get_categories,
     playlist_search,
+    get_playlist,
 };

--- a/server/providers/spotify/playlist_search.js
+++ b/server/providers/spotify/playlist_search.js
@@ -32,10 +32,10 @@ export const playlist_search = (res, key, query) => {
     const query_results = JSON.parse(response.body);
     if (response.statusCode != 200) {
       res.status(response.statusCode).send(query_results);
-      return;
+    } else {
+      res.status(response.statusCode).send(
+        process_results(query_results)
+      );
     }
-    res.status(response.statusCode).send(
-      process_results(query_results)
-    );
   });    
 };

--- a/server/providers/spotify/urls.js
+++ b/server/providers/spotify/urls.js
@@ -1,7 +1,9 @@
 export const urls = {
-    authorize: 'https://accounts.spotify.com/api/token',
-    get_categories: 'https://api.spotify.com/v1/browse/categories',
-    playlist_search: (query) => (
-        `https://api.spotify.com/v1/search?q=${query}&type=playlist`
-    ),
+  authorize: 'https://accounts.spotify.com/api/token',
+  get_categories: 'https://api.spotify.com/v1/browse/categories',
+  playlist_search: query => `https://api.spotify.com/v1/search?q=${query}&type=playlist`,
+  get_playlist: id => (
+    `https://api.spotify.com/v1/playlists/${id}/` +
+    `tracks?fields=items(track(name,preview_url,id,album(images)))`
+  )
 };

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -1,52 +1,51 @@
 import express from 'express';
 import { PORT } from '~/config';
 import {
-    authorize,
-    get_categories,
-    playlist_search,
+  authorize,
+  get_categories,
+  playlist_search,
+  get_playlist,
 } from '@/providers/spotify';
 
 
 const app = express();
 
-app.get('/v1', (req, res) => {
-    res.send('Tune Up!');
+app.get('/v1/', (req, res) => {
+  res.send('Tune Up!');
 });
 
 app.get('/v1/spotify/authorize/', (req, res) => {
-    try {
-        authorize(res);
-    } catch (e) {
-        res.status(500).send(e);
-    }
+    authorize(res);
 });
 
 app.get('/v1/spotify/get_categories/', (req, res) => {
-    if (!req.query.key) {
-        res.status(400).send('There was no auth key provided');
-        return;
-    }
-    try {
-        get_categories(res, req.query.key);
-    } catch (e) {
-        res.status(500).send(e);
-    }
+  if (!req.query.key) {
+    res.status(400).send('There was no auth key provided');
+  } else {
+    get_categories(res, req.query.key);
+  }
 });
 
 app.get('/v1/spotify/playlist_search/', (req, res) => {
-    if (!req.query.key) {
-        res.status(400).send('There was no auth key provided');
-    } else if (!req.query.q) {
-        res.status(400).send('There was no query provided');
-    } else {
-        try {
-            playlist_search(res, req.query.key, req.query.q);
-        } catch (e) {
-            res.status(500).send(e);
-        }
-    }
+  if (!req.query.key) {
+    res.status(400).send('There was no auth key provided');
+  } else if (!req.query.q) {
+    res.status(400).send('There was no query provided');
+  } else {
+    playlist_search(res, req.query.key, req.query.q);
+  }
+});
+
+app.get('/v1/spotify/get_playlist/', (req, res) => {
+  if (!req.query.key) {
+    res.status(400).send('There was no auth key provided');
+  } else if (!req.query.id) {
+    req.status(400).send('There was no playlist ID provided')
+  } else {
+    get_playlist(res, req.query.key, req.query.id);
+  }
 });
 
 app.listen(PORT, () => {
-    console.log(`Listening on port ${PORT}...`);
+  console.log(`Listening on port ${PORT}...`);
 });


### PR DESCRIPTION
- It is actually much easier on the front end to recieve `id` value from the API response than `href`
- Changed `playlist_search` endpoint to return `id` instead of `href`