### PR TITLE
Fixed Crash on get_playlist_from_category endpoint

### DIFF
--- a/server/providers/spotify/get_playlists_from_category.js
+++ b/server/providers/spotify/get_playlists_from_category.js
@@ -17,7 +17,7 @@ export const get_playlists_from_category = (res, key, id) => {
     }
     const returned_tracks = JSON.parse(response.body);
     if (response.statusCode != 200) {
-      res.status(response.statusCode).send(query_results);
+      res.status(response.statusCode).send(returned_tracks);
     } else {
       res.status(response.statusCode).send(
         process_body(returned_tracks)


### PR DESCRIPTION
- Was previously using an undeclared variable during handling under case of a non 20x response﻿
